### PR TITLE
External route URLs with ports

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,15 @@ async function buildManifest ({ arc, inventory, stage = 'testing' }) {
     manifest.any = {
       ...manifest.any,
       ...Object.entries(externalStageRoutes).reduce(
-        (routes, [ key, value ]) => ({ ...routes, [`${externalPrefix}${key}`]: value }),
+        (routes, [ key, value ]) => {
+          try {
+            new URL(value)
+          }
+          catch {
+            throw new TypeError(`Invalid URL "${value}" for external route "${key}"`)
+          }
+          return { ...routes, [`${externalPrefix}${key}`]: value }
+        },
         {},
       ),
     }

--- a/route.js
+++ b/route.js
@@ -35,9 +35,14 @@ module.exports = function route (...args) {
     routes = {}
   }
 
-  const rawPath = routes[method?.toLowerCase() || 'get']?.[name] || routes.any?.[name]
+  let url
+  let rawPath = routes[method?.toLowerCase() || 'get']?.[name] || routes.any?.[name]
   if (rawPath === undefined) {
     throw new ReferenceError(`No route named "${name}"${method !== undefined ? ` for method ${method.toUpperCase()}` : ''}`)
+  }
+  if (name.startsWith('external.')) {
+    url = new URL(rawPath)
+    rawPath = url.pathname
   }
 
   let query = params
@@ -50,6 +55,14 @@ module.exports = function route (...args) {
       .reduce((obj, key) => ({ ...obj, [key]: query[key] }), {})
     return value
   })
+
+  if (name.startsWith('external.')) {
+    url.pathname = path
+    url.search = Object.keys(query).length > 0
+      ? `?${stringify(query)}`
+      : ''
+    return url.toString()
+  }
 
   return `${path}${Object.keys(query).length > 0
     ? `?${stringify(query)}`


### PR DESCRIPTION
Fixes #9 by passing external route values through the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL_API) and then only doing path parameter substitution on the path of a URL.

To improve the DX, this also verifies URLs are parsable at Sandbox start up to avoid the issue of configuring an invalid external route and only discovering when called later on.